### PR TITLE
Correct Order Portal Columns

### DIFF
--- a/orderportal/templates/order/list.html
+++ b/orderportal/templates/order/list.html
@@ -88,9 +88,6 @@
           <th width="30%">Title</th>
           <th>Form</th>
           <th>Owner</th>
-          {% if settings['ORDERS_LIST_TAGS'] %}
-          <th width="5%">{{ terminology('Tags') }}</th>
-          {% end %}
           {% if settings['ORDERS_LIST_OWNER_UNIVERSITY'] %}
           <th>Owner university</th>
           {% end %}
@@ -99,6 +96,9 @@
           {% end %}
           {% if settings['ORDERS_LIST_OWNER_GENDER'] %}
           <th>Owner gender</th>
+          {% end %}
+          {% if settings['ORDERS_LIST_TAGS'] %}
+          <th width="5%">{{ terminology('Tags') }}</th>
           {% end %}
           {% for f in settings['ORDERS_LIST_FIELDS'] %}
           <th>{{ f.replace('_', ' ').capitalize() }}</th>


### PR DESCRIPTION
TO TEST:

1. Launch OP instance
2. Create admin
3. Log in and create a form, then an order
4. Select "Order list configuration" -> Display dptmn, University, Gender
5. Go to Orders and check that the order is correct


Before:

![image](https://github.com/user-attachments/assets/361b7892-5ba8-4eaf-9e4b-b156cd59dc00)

After:

![image](https://github.com/user-attachments/assets/63acaa38-c695-4ec4-b176-95f9a0b76864)
