### PR TITLE
Change from Docker/ to docker/ in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     # TODO set up non root user to simulate prod enviroment (look dds_web for example)
     user: "root:root"
     build:
-      dockerfile: Docker/Dockerfile-prod
+      dockerfile: docker/Dockerfile-prod
       context: ./
     working_dir: /code/orderportal
     command: sh -c "python ./cli.py create-database --silent && python ./main.py"

--- a/docker/couchdb/local.ini
+++ b/docker/couchdb/local.ini
@@ -7,6 +7,7 @@
 [couchdb]
 ;max_document_size = 4294967296 ; bytes
 single_node=true
+uuid = 17a21a011a5d0fbcc62bcd8a7eeff3aa
 
 [httpd]
 ;port = 5984
@@ -92,3 +93,4 @@ ssl_certificate_max_depth = 1
 ; changing this.
 [admins]
 ;admin = mysecretpassword
+orderportal_account = -pbkdf2-9aeec48473d9346e64fd6136e31eda34f548a500,26fbb0529832c55831c6bac1b2dd1547,10

--- a/docker/couchdb/local.ini
+++ b/docker/couchdb/local.ini
@@ -7,7 +7,6 @@
 [couchdb]
 ;max_document_size = 4294967296 ; bytes
 single_node=true
-uuid = 17a21a011a5d0fbcc62bcd8a7eeff3aa
 
 [httpd]
 ;port = 5984
@@ -93,4 +92,3 @@ ssl_certificate_max_depth = 1
 ; changing this.
 [admins]
 ;admin = mysecretpassword
-orderportal_account = -pbkdf2-9aeec48473d9346e64fd6136e31eda34f548a500,26fbb0529832c55831c6bac1b2dd1547,10


### PR DESCRIPTION
When running `docker compose up`, it complains that "Docker/Dockerfile-prod" doesn't exist. The folder is `docker`, not `Docker`. Changing this fixed the issue. 